### PR TITLE
Add service CRUD API with tests

### DIFF
--- a/packages/backend/src/__tests__/service.test.ts
+++ b/packages/backend/src/__tests__/service.test.ts
@@ -1,0 +1,40 @@
+import { ServiceModel } from '../models/service';
+import * as service from '../services/service';
+
+jest.mock('../models/service');
+
+const ServiceModelMock = jest.mocked(ServiceModel, true);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('service layer', () => {
+  test('createService checks overlap and creates', async () => {
+    ServiceModelMock.findOne = jest.fn().mockResolvedValue(null) as any;
+    ServiceModelMock.create = jest.fn().mockResolvedValue({ id: '1' }) as any;
+    const data: any = {
+      name: 'Table',
+      availableFrom: new Date('2024-01-01'),
+      availableTo: new Date('2024-01-02'),
+      rates: { hourly: 10, daily: 100 },
+      quantity: 1,
+    };
+    const result = await service.createService(data);
+    expect(ServiceModelMock.findOne).toHaveBeenCalled();
+    expect(ServiceModelMock.create).toHaveBeenCalledWith(data);
+    expect(result).toEqual({ id: '1' });
+  });
+
+  test('createService throws on overlap', async () => {
+    ServiceModelMock.findOne = jest.fn().mockResolvedValue({}) as any;
+    const data: any = {
+      name: 'Table',
+      availableFrom: new Date('2024-01-01'),
+      availableTo: new Date('2024-01-02'),
+      rates: { hourly: 10, daily: 100 },
+      quantity: 1,
+    };
+    await expect(service.createService(data)).rejects.toThrow('service availability overlaps');
+  });
+});

--- a/packages/backend/src/__tests__/services.controller.test.ts
+++ b/packages/backend/src/__tests__/services.controller.test.ts
@@ -1,0 +1,48 @@
+import { Request, Response } from 'express';
+import * as controller from '../controllers/services';
+import * as serviceLayer from '../services/service';
+
+jest.mock('../services/service');
+
+const serviceMock = jest.mocked(serviceLayer, true);
+
+describe('services controller', () => {
+  test('create success', async () => {
+    const req = { body: {} } as Request;
+    const json = jest.fn();
+    const res = { status: jest.fn().mockReturnThis(), json } as unknown as Response;
+    serviceMock.createService.mockResolvedValue({ id: '1' } as any);
+    await controller.create(req, res);
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(json).toHaveBeenCalledWith({ id: '1' });
+  });
+
+  test('create failure', async () => {
+    const req = { body: {} } as Request;
+    const json = jest.fn();
+    const res = { status: jest.fn().mockReturnThis(), json } as unknown as Response;
+    serviceMock.createService.mockRejectedValue(new Error('bad'));
+    await controller.create(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith({ message: 'bad' });
+  });
+
+  test('update not found', async () => {
+    const req = { params: { id: '1' }, body: {} } as unknown as Request;
+    const json = jest.fn();
+    const res = { status: jest.fn().mockReturnThis(), json } as unknown as Response;
+    serviceMock.updateService.mockResolvedValue(null as any);
+    await controller.update(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(json).toHaveBeenCalledWith({ message: 'not found' });
+  });
+
+  test('remove success', async () => {
+    const req = { params: { id: '1' } } as unknown as Request;
+    const json = jest.fn();
+    const res = { status: jest.fn().mockReturnThis(), json } as unknown as Response;
+    serviceMock.deleteService.mockResolvedValue({ id: '1' } as any);
+    await controller.remove(req, res);
+    expect(json).toHaveBeenCalledWith({ id: '1' });
+  });
+});

--- a/packages/backend/src/controllers/services.ts
+++ b/packages/backend/src/controllers/services.ts
@@ -1,0 +1,32 @@
+import { Request, Response } from 'express';
+import * as serviceService from '../services/service';
+
+export async function create(req: Request, res: Response) {
+  try {
+    const created = await serviceService.createService(req.body);
+    res.status(201).json(created);
+  } catch (err: any) {
+    res.status(400).json({ message: err.message });
+  }
+}
+
+export async function list(req: Request, res: Response) {
+  const services = await serviceService.getServices();
+  res.json(services);
+}
+
+export async function update(req: Request, res: Response) {
+  try {
+    const updated = await serviceService.updateService(req.params.id, req.body);
+    if (!updated) return res.status(404).json({ message: 'not found' });
+    res.json(updated);
+  } catch (err: any) {
+    res.status(400).json({ message: err.message });
+  }
+}
+
+export async function remove(req: Request, res: Response) {
+  const removed = await serviceService.deleteService(req.params.id);
+  if (!removed) return res.status(404).json({ message: 'not found' });
+  res.json(removed);
+}

--- a/packages/backend/src/models/service.ts
+++ b/packages/backend/src/models/service.ts
@@ -1,0 +1,37 @@
+import { Schema, model, Document } from 'mongoose';
+
+export interface Rate {
+  hourly: number;
+  daily: number;
+}
+
+export interface ServiceDocument extends Document {
+  name: string;
+  description?: string;
+  availableFrom: Date;
+  availableTo: Date;
+  rates: Rate;
+  quantity: number;
+}
+
+const rateSchema = new Schema<Rate>(
+  {
+    hourly: { type: Number, required: true },
+    daily: { type: Number, required: true },
+  },
+  { _id: false }
+);
+
+const serviceSchema = new Schema<ServiceDocument>(
+  {
+    name: { type: String, required: true },
+    description: { type: String },
+    availableFrom: { type: Date, required: true },
+    availableTo: { type: Date, required: true },
+    rates: { type: rateSchema, required: true },
+    quantity: { type: Number, required: true },
+  },
+  { timestamps: true }
+);
+
+export const ServiceModel = model<ServiceDocument>('Service', serviceSchema);

--- a/packages/backend/src/routes/services.ts
+++ b/packages/backend/src/routes/services.ts
@@ -1,12 +1,14 @@
 import { Router } from 'express';
 import { requireContractor } from '../middleware/auth';
+import * as controller from '../controllers/services';
 
 const router = Router();
 
 router.use(requireContractor);
 
-router.get('/', (_, res) => {
-  res.json([]);
-});
+router.get('/', controller.list);
+router.post('/', controller.create);
+router.patch('/:id', controller.update);
+router.delete('/:id', controller.remove);
 
 export default router;

--- a/packages/backend/src/services/service.ts
+++ b/packages/backend/src/services/service.ts
@@ -1,0 +1,37 @@
+import { FilterQuery } from 'mongoose';
+import { ServiceModel, ServiceDocument } from '../models/service';
+
+export async function createService(data: Partial<ServiceDocument>): Promise<ServiceDocument> {
+  await ensureNoOverlap(data.name!, data.availableFrom!, data.availableTo!);
+  return ServiceModel.create(data);
+}
+
+export async function getServices(filter: FilterQuery<ServiceDocument> = {}): Promise<ServiceDocument[]> {
+  return ServiceModel.find(filter).exec();
+}
+
+export async function updateService(id: string, data: Partial<ServiceDocument>): Promise<ServiceDocument | null> {
+  if (data.availableFrom && data.availableTo) {
+    await ensureNoOverlapForUpdate(id, data.name!, data.availableFrom, data.availableTo);
+  }
+  return ServiceModel.findByIdAndUpdate(id, data, { new: true }).exec();
+}
+
+export async function deleteService(id: string): Promise<ServiceDocument | null> {
+  return ServiceModel.findByIdAndDelete(id).exec();
+}
+
+async function ensureNoOverlap(name: string, from: Date, to: Date, excludeId?: string) {
+  const query: FilterQuery<ServiceDocument> = {
+    name,
+    availableFrom: { $lte: to },
+    availableTo: { $gte: from },
+  };
+  if (excludeId) query._id = { $ne: excludeId };
+  const existing = await ServiceModel.findOne(query).exec();
+  if (existing) throw new Error('service availability overlaps');
+}
+
+async function ensureNoOverlapForUpdate(id: string, name: string, from: Date, to: Date) {
+  await ensureNoOverlap(name, from, to, id);
+}


### PR DESCRIPTION
## Summary
- implement Mongoose `Service` schema
- add service layer with availability overlap checks
- implement controller and REST routes for `/services`
- add Jest unit tests mocking Mongoose

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6870499cf034832b992852a36202b5e0