### PR TITLE
Add orders dashboard UI

### DIFF
--- a/packages/frontend/src/__tests__/OrdersPage.test.tsx
+++ b/packages/frontend/src/__tests__/OrdersPage.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { OrdersPage } from '../components/OrdersPage';
+
+const createWrapper = () => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+};
+
+let fetchMock: jest.Mock;
+
+beforeEach(() => {
+  fetchMock = jest.fn();
+  (global as any).fetch = fetchMock;
+});
+
+afterEach(() => {
+  fetchMock.mockReset();
+});
+
+test('opens order detail and accepts order', async () => {
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    json: async () => [
+      {
+        _id: '1',
+        status: 'pending',
+        lineItems: [
+          { _id: 'li1', service: { _id: 's1', name: 'A' }, quantity: 1, status: 'pending' },
+        ],
+      },
+    ],
+  });
+
+  render(<OrdersPage />, { wrapper: createWrapper() });
+  expect(await screen.findByText('pending')).toBeInTheDocument();
+
+  fireEvent.click(screen.getAllByText('1')[0]);
+  expect(screen.getByTestId('order-detail')).toBeInTheDocument();
+
+  fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+  fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [] });
+  fireEvent.click(screen.getByText('Accept'));
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/orders/1/accept', expect.anything()));
+});
+
+test('partial reject sends line item ids', async () => {
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    json: async () => [
+      {
+        _id: '1',
+        status: 'pending',
+        lineItems: [
+          { _id: 'li1', service: { _id: 's1', name: 'A' }, quantity: 1, status: 'pending' },
+          { _id: 'li2', service: { _id: 's2', name: 'B' }, quantity: 2, status: 'pending' },
+        ],
+      },
+    ],
+  });
+
+  render(<OrdersPage />, { wrapper: createWrapper() });
+  expect(await screen.findByText('pending')).toBeInTheDocument();
+  fireEvent.click(screen.getAllByText('1')[0]);
+
+  const checkbox = screen.getByLabelText('select-li1');
+  fireEvent.click(checkbox);
+
+  fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+  fetchMock.mockResolvedValueOnce({ ok: true, json: async () => [] });
+  fireEvent.click(screen.getByText('Reject'));
+
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+    '/orders/1/reject',
+    expect.objectContaining({
+      method: 'PATCH',
+      body: JSON.stringify({ lineItemIds: ['li1'] }),
+    })
+  ));
+});
+

--- a/packages/frontend/src/components/OrdersPage.tsx
+++ b/packages/frontend/src/components/OrdersPage.tsx
@@ -1,0 +1,136 @@
+import React, { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useToast } from '../toast';
+
+export interface LineItem {
+  _id: string;
+  service: { _id: string; name: string };
+  quantity: number;
+  status: 'pending' | 'accepted' | 'rejected';
+}
+
+export interface Order {
+  _id: string;
+  status: 'pending' | 'accepted' | 'rejected';
+  lineItems: LineItem[];
+}
+
+interface DetailProps {
+  order: Order;
+  onClose: () => void;
+}
+
+const OrderDetail: React.FC<DetailProps> = ({ order, onClose }) => {
+  const toast = useToast();
+  const queryClient = useQueryClient();
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const acceptMutation = useMutation(async () => {
+    const res = await fetch(`/orders/${order._id}/accept`, { method: 'PATCH' });
+    if (!res.ok) throw new Error('failed');
+    return res.json();
+  }, {
+    onSuccess: () => {
+      toast.success('Order accepted');
+      queryClient.invalidateQueries('orders');
+      onClose();
+    },
+    onError: () => toast.error('Failed to accept order'),
+  });
+
+  const rejectMutation = useMutation(async () => {
+    const body = selected.length ? { lineItemIds: selected } : {};
+    const res = await fetch(`/orders/${order._id}/reject`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error('failed');
+    return res.json();
+  }, {
+    onSuccess: () => {
+      toast.success('Order updated');
+      queryClient.invalidateQueries('orders');
+      onClose();
+    },
+    onError: () => toast.error('Failed to reject order'),
+  });
+
+  const toggle = (id: string) => {
+    setSelected((s) => (s.includes(id) ? s.filter((x) => x !== id) : [...s, id]));
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center" data-testid="order-detail">
+      <div className="bg-white p-4 space-y-2">
+        <h2 className="text-lg font-bold">Order {order._id}</h2>
+        <table className="min-w-full border">
+          <thead>
+            <tr className="bg-gray-100">
+              <th></th>
+              <th>Item</th>
+              <th>Qty</th>
+            </tr>
+          </thead>
+          <tbody>
+            {order.lineItems.map((li) => (
+              <tr key={li._id}>
+                <td>
+                  <input
+                    type="checkbox"
+                    aria-label={`select-${li._id}`}
+                    checked={selected.includes(li._id)}
+                    onChange={() => toggle(li._id)}
+                  />
+                </td>
+                <td>{li.service.name}</td>
+                <td>{li.quantity}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="flex gap-2 justify-end">
+          <button onClick={onClose} className="px-2 py-1 border">Close</button>
+          <button onClick={() => acceptMutation.mutate()} className="px-2 py-1 bg-green-500 text-white">Accept</button>
+          <button onClick={() => rejectMutation.mutate()} className="px-2 py-1 bg-red-500 text-white">Reject</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const OrdersPage: React.FC = () => {
+  const { data } = useQuery<Order[]>(['orders'], async () => {
+    const res = await fetch('/orders?status=pending');
+    if (!res.ok) throw new Error('error');
+    return res.json();
+  }, { refetchInterval: 5000 });
+
+  const [selected, setSelected] = useState<Order | null>(null);
+
+  return (
+    <div className="p-4 space-y-2">
+      <h1 className="text-xl font-bold">Orders</h1>
+      <table className="min-w-full border" data-testid="orders-table">
+        <thead>
+          <tr className="bg-gray-100">
+            <th>ID</th>
+            <th>Status</th>
+            <th>Items</th>
+          </tr>
+        </thead>
+        <tbody>
+          {(data || []).map((o) => (
+            <tr key={o._id} onClick={() => setSelected(o)} className="cursor-pointer hover:bg-gray-50">
+              <td>{o._id}</td>
+              <td>{o.status}</td>
+              <td>{o.lineItems.length}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {selected && <OrderDetail order={selected} onClose={() => setSelected(null)} />}
+    </div>
+  );
+};
+


### PR DESCRIPTION
## Summary
- add `OrdersPage` component to view pending orders
- support accept and partial reject flows
- cover order flows with new RTL tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6870b42b298c832b8e60df1126122853